### PR TITLE
fix bug of SuperScale::superResoutionScale

### DIFF
--- a/Project_android/ncnn-android-nanodet/app/src/main/jni/scale/super_scale.cpp
+++ b/Project_android/ncnn-android-nanodet/app/src/main/jni/scale/super_scale.cpp
@@ -59,7 +59,7 @@ int SuperScale::superResoutionScale(const Mat &src, Mat &dst) {
     ncnn::Mat prob;
     ex.extract("fc", prob);
 
-    dst = Mat(prob.w, prob.h, CV_8UC1);
+    dst = Mat(prob.h, prob.w, CV_8UC1);
 
     int cnt = 0;
     for (int row = 0; row < prob.h; row++) {


### PR DESCRIPTION
The code below 

    dst = Mat(prob.w, prob.h, CV_8UC1) 

should be 

    dst = Mat(prob.h, prob.w, CV_8UC1);

This bug make my app crash , and i found the bug while debuging.



`int SuperScale::superResoutionScale(const Mat &src, Mat &dst) {
    ncnn::Mat blob = ncnn::Mat::from_pixels(src.data, ncnn::Mat::PIXEL_GRAY, src.cols, src.rows);
    const float norm_vals[3] = { 1.f / 255.f };
    blob.substract_mean_normalize(0, norm_vals);

    ncnn::Extractor ex = srnet_.create_extractor();
    ex.input("data", blob);

    ncnn::Mat prob;
    ex.extract("fc", prob);

    dst = Mat(prob.w, prob.h, CV_8UC1);

    int cnt = 0;
    for (int row = 0; row < prob.h; row++) {
        for (int col = 0; col < prob.w; col++) {
            float pixel = prob[cnt++] * 255.0;
            dst.at<uint8_t>(row, col) = static_cast<uint8_t>(CLIP(pixel, 0.0f, 255.0f));
        }
    }

    return 0;
}`